### PR TITLE
Replace content::Custom with Tuple

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "ghcr.io/devcontainers/features/rust:1": {
+      "version": "nightly",
+      "profile": "complete"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,6 @@
 {
   "image": "mcr.microsoft.com/devcontainers/universal:2",
   "features": {
-    "ghcr.io/devcontainers/features/rust:1": {
-      "version": "nightly",
-      "profile": "complete"
-    }
+    "ghcr.io/devcontainers/features/rust:1": {}
   }
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ status = "as-is"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rocket = "0.5.0-rc.1"
+rocket = "0.5.0-rc.2"
 serde = "1.0.130"
 serde_urlencoded = "0.7.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ use rocket::form::prelude as form;
 use rocket::http::uri::fmt::{Formatter as UriFormatter, FromUriParam, Query, UriDisplay};
 use rocket::http::{ContentType, Status};
 use rocket::request::{local_cache, Request};
-use rocket::response::{self, content, Responder};
+use rocket::response::{self, Responder};
 use serde::{Deserialize, Serialize};
 
 /// The UrlEncoded guard: easily consume x-www-form-urlencoded requests.
@@ -207,7 +207,7 @@ impl<'r, T: Serialize> Responder<'r, 'static> for UrlEncoded<T> {
             Status::InternalServerError
         })?;
 
-        content::Custom(ContentType::Form, string).respond_to(req)
+        (ContentType::Form, string).respond_to(req)
     }
 }
 


### PR DESCRIPTION
Changes in this PR:

- Add .devcontainer with the rust environment to enable Codespaces
- Bump Rocket version to 0.5.0-rc.2
- Remove content::Custom, Closes #9 